### PR TITLE
Airborne mode support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,8 @@ Go to File, Preferences and set the following URL for the additional board files
 
 http://downloads.sodaq.net/package_sodaq_samd_index.json
 
+Then open the "boards manager" and install the SODAQ SAMD Boards package. You can now select the SODAQ ONE as target board in the IDE.
+
 ##  Configuration Menu
 
 After compiling the source code and uploading it to the board you will be able to configure the board through a menu.

--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ After compiling the source code and uploading it to the board you will be able t
 
 Just open the Arduino Serial Monitor (at 9600 baud) and you will get this menu:
 ```
-** SodaqOne Universal Tracker v3 - 6.0.2 **
+** SodaqOne Universal Tracker v3 - 6.0.0 **
 LoRa HWEUI: 0004A30B00198185
  -> CPU reset by Software [64]
 
@@ -36,6 +36,7 @@ GPS
   GPS Fix Timeout (sec)      (gft=): 120
   Minimum sat count          (sat=): 4
   Num Coords to Upload       (num=): 1
+  GPS dynamic model          (gdm=): 0
 
 On-the-move Functionality 
   Acceleration% (100% = 8g)  (acc=): 0
@@ -91,7 +92,17 @@ the best GPS fix found (if any) is used.
 
 For redundancy we could configure a repeat count. The value of the repeat count tells us to send the Lora frame an additional number of times (default 0) for redundancy.
 
-The Lora frame contains the following data. The minimum frame size is 21 bytes, the maximum frame size 51 bytes, depending on the number of coordinates we have configured to be sent.
+For special applications like high-altitude ballooning, the GPS might need to operate with a different dynamics model for making calculations. Use the `gdm=` operator to chose one of the following models:
+
+- **0: portable** (default) Applications with low acceleration, e.g. portable devices. Suitable for most situations.
+- **2: stationary** Used in timing applications (antenna must be stationary) or other stationary applications. Velocity restricted to 0 m/s. Zero dynamics assumed.
+- **3: pedestrian** Applications with low acceleration and speed, e.g. how a pedestrian would move. Low acceleration assumed.
+- **4: automotive** Used for applications with equivalent dynamics to those of a passenger car. Low vertical acceleration assumed.
+- **5: sea** Recommended for applications at sea, with zero vertical velocity. Zero vertical velocity assumed. Sea level assumed.
+- **6: airborne with <1g acceleration** Used for applications with a higher dynamic range and greater vertical acceleration than a passenger car. No 2D position fixes supported.
+- **7: airborne with <2g acceleration** Recommended for typical airborne environments. No 2D position fixes supported.
+- **8: airborne with <4g acceleration** Only recommended for extremely dynamic environments. No 2D position fixes supported.
+
 
 #### LoRa Connection
 
@@ -108,6 +119,8 @@ The firmware supports, except for the default and alternative fix intervals, a t
 
 
 #### LoRa Frame content
+
+The Lora frame contains the following data. The minimum frame size is 21 bytes, the maximum frame size 51 bytes, depending on the number of coordinates we have configured to be sent.
 
 | Description | Length |
 | --- | --- |
@@ -131,8 +144,6 @@ The firmware supports, except for the default and alternative fix intervals, a t
 #### Remote (over the air) re-configuration
 
 You can send the following configuration parameters back to the device (as part as the LoRaWAN class A communication protocol)
-
-
 
 | Description | Length |
 | --- | --- |

--- a/SodaqOneTracker_v3/Config.cpp
+++ b/SodaqOneTracker_v3/Config.cpp
@@ -78,6 +78,7 @@ void ConfigParams::reset()
     _alternativeFixToHours = 0;
     _alternativeFixToMinutes = 0;
     _gpsFixTimeout = 120;
+    _gpsDynModel = 0;
 
     memset(_devAddrOrEUI, 0x30, sizeof(_devAddrOrEUI) - 1);
     _devAddrOrEUI[sizeof(_devAddrOrEUI) - 1] = '\0';
@@ -142,6 +143,7 @@ static const Command args[] = {
     { "GPS Fix Timeout (sec)     ", "gft=", Command::set_uint16, Command::show_uint16, &params._gpsFixTimeout },
     { "Minimum sat count         ", "sat=", Command::set_uint8, Command::show_uint8, &params._gpsMinSatelliteCount },
     { "Num Coords to Upload      ", "num=", Command::set_uint8, Command::show_uint8, &params._coordinateUploadCount },
+    { "GPS dynamic model         ", "gdm=", Command::set_uint8, Command::show_uint8, &params._gpsDynModel },
     { "On-the-move Functionality ", 0,      0,                  Command::show_title, 0 },
     { "Acceleration% (100% = 8g) ", "acc=", Command::set_uint8, Command::show_uint8, &params._accelerationPercentage },
     { "Acceleration Duration     ", "acd=", Command::set_uint8, Command::show_uint8, &params._accelerationDuration },
@@ -263,6 +265,11 @@ bool ConfigParams::checkConfig(Stream& stream)
 
     if (_accelerationPercentage > 100) {
         stream.println("Acceleration% must not be more than 100");
+        fail = true;
+    }
+
+    if (_gpsDynModel > 8) {
+        stream.println("GPS Dynamic Model must not be more than 8");
         fail = true;
     }
 

--- a/SodaqOneTracker_v3/Config.h
+++ b/SodaqOneTracker_v3/Config.h
@@ -73,6 +73,7 @@ struct ConfigParams
     uint8_t _gpsMinSatelliteCount;
     uint8_t _coordinateUploadCount;
     uint8_t _repeatCount;
+    uint8_t _gpsDynModel;
     
     uint8_t _isDebugOn;
     uint8_t _isCayennePayloadEnabled;
@@ -120,6 +121,7 @@ public:
     uint8_t getGpsMinSatelliteCount() const{ return _gpsMinSatelliteCount; }
     uint8_t getCoordinateUploadCount() const { return _coordinateUploadCount; }
     uint8_t getRepeatCount() const { return _repeatCount; }
+    uint8_t getGpsDynModel() const { return _gpsDynModel; }
 
     uint8_t getIsDebugOn() const { return _isDebugOn; }
     uint8_t getIsCayennePayloadEnabled() const { return _isCayennePayloadEnabled; }

--- a/SodaqOneTracker_v3/SodaqOneTracker_v3.ino
+++ b/SodaqOneTracker_v3/SodaqOneTracker_v3.ino
@@ -939,8 +939,8 @@ void setGpsActive(bool on)
             return;
         }
 
-        ublox.CfgMsg(UBX_NAV_PVT, 1); // Navigation Position Velocity TimeSolution
-        ublox.funcNavPvt = delegateNavPvt;
+        sodaq_wdt_safe_delay(15);
+
 
         // Fetch the Navigation Engine Settings
         NavigationEngineSettings navSettings;
@@ -974,6 +974,11 @@ void setGpsActive(bool on)
             debugPrintln("ublox.setNavEngineSettings failed.");
             return;
         }
+
+        sodaq_wdt_safe_delay(15);
+
+        ublox.CfgMsg(UBX_NAV_PVT, 1); // Navigation Position Velocity TimeSolution
+        ublox.funcNavPvt = delegateNavPvt;
     }
     else {
         ublox.disable();

--- a/SodaqOneTracker_v3/ublox.cpp
+++ b/SodaqOneTracker_v3/ublox.cpp
@@ -254,21 +254,45 @@ void UBlox::sendraw() {
     this->db_printf("UBlox::sendraw() == %4.4x\n",id);
 }
 
+/*
+ * Gets the navigational engine settings.
+ * See "CFG-NAV5" in u-blox protocol description.
+ */
+bool UBlox::getNavEngineSettings(NavigationEngineSettings* navDynModel) {
+    uint8_t buffer[4];
+    buffer[0] = 0x06; // Class
+    buffer[1] = 0x24; // Id
+    
+    buffer[2] = 0;    // Length LSB
+    buffer[3] = 0;    // Length MSB
+
+    (void) this->send(buffer,sizeof(buffer));
+    
+    // wait for response and copy answer into navDynModel
+    return this->wait(0x0624,sizeof(NavigationEngineSettings),navDynModel);
+}
+
+/* 
+ *  Sets the message rate.
+ *  See "CFG-MSG" in u-blox protocol description.
+ */
 void UBlox::CfgMsg(uint16_t Msg,uint8_t rate) {
-    uint8_t buffer[7];
-    //
-    buffer[0] = 0x06;
-    buffer[1] = 0x01;
-    buffer[2] = 0x03;
-    buffer[3] = 0;
-    buffer[4] = (Msg >> 8) & 0xff;
-    buffer[5] = Msg & 0xff;
-    buffer[6] = rate;
+    uint8_t buffer[7];    
+    buffer[0] = 0x06;              // Class
+    buffer[1] = 0x01;              // Id
+    buffer[2] = 0x03;              // Length LSB
+    buffer[3] = 0;                 // Length MSB
+    buffer[4] = (Msg >> 8) & 0xff; // Message Class
+    buffer[5] = Msg & 0xff;        // Message Id
+    buffer[6] = rate;              // Send rate on port
     // Push message on Wire
     (void) this->send(buffer,7);
     this->wait();
 }
 
+/*
+ * See "CFG-TP5" in u-blox protocol description.
+ */
 int UBlox::setTimePulseParameters (TimePulseParameters *Tpp) {
     // Warning this overwrites the receive buffer !!!
     payLoad_.buffer[0] = 0x06;
@@ -281,14 +305,17 @@ int UBlox::setTimePulseParameters (TimePulseParameters *Tpp) {
     return this->wait();
 }
 
+/*
+ * See "CFG-TP5" in u-blox protocol description.
+ */
 bool UBlox::getTimePulseParameters(uint8_t tpIdx,TimePulseParameters* tpp) {
     uint8_t buffer[5];
     //
-    buffer[0] = 0x06;
-    buffer[1] = 0x31;
-    buffer[2] = 1;
-    buffer[3] = 0;
-    buffer[4] = tpIdx;
+    buffer[0] = 0x06;  // Class
+    buffer[1] = 0x31;  // Id
+    buffer[2] = 1;     // Length LSB
+    buffer[3] = 0;     // Length MSB
+    buffer[4] = tpIdx; // thIdx
     // Push message on Wire
     (void) this->send(buffer,5);
     // wait for response
@@ -310,10 +337,10 @@ int UBlox::setPortConfigurationDDC (PortConfigurationDDC *pcd) {
 bool UBlox::getPortConfigurationDDC(PortConfigurationDDC* pcd) {
     uint8_t buffer[4];
     //
-    buffer[0] = 0x06;
-    buffer[1] = 0x00;
-    buffer[2] = 0;
-    buffer[3] = 0;
+    buffer[0] = 0x06; // Class
+    buffer[1] = 0x00; // Id
+    buffer[2] = 0;    // Length LSB
+    buffer[3] = 0;    // Length MSB
     // Push message on Wire
     (void) this->send(buffer,4);
     // wait for response
@@ -366,13 +393,15 @@ bool UBlox::wait(uint16_t rid,int reqLength,void *d) {
                         found = true;
                     }
                     else
-                        db_printf("Oops %d %d\n",payLoad_.length,reqLength);
+                        db_printf("Oops payload size was %d but requested size was %d.\n",payLoad_.length,reqLength);
                 }
                 else if (pid > 0)
                 	this->dispatchMessage(pid);
             }
         } while (bytes);
         //
+    } else {
+      db_printf("No bytes available for %x.\n",rid);
     }
     return found;
 }

--- a/SodaqOneTracker_v3/ublox.cpp
+++ b/SodaqOneTracker_v3/ublox.cpp
@@ -272,6 +272,22 @@ bool UBlox::getNavEngineSettings(NavigationEngineSettings* navDynModel) {
     return this->wait(0x0624,sizeof(NavigationEngineSettings),navDynModel);
 }
 
+/*
+ * Sets the navigational engine settings.
+ * See "CFG-NAV5" in u-blox protocol description.
+ */
+bool UBlox::setNavEngineSettings(NavigationEngineSettings* navDynModel) {
+    // Warning: this overwrites the receive buffer.
+    payLoad_.buffer[0] = 0x06;                             // Class
+    payLoad_.buffer[1] = 0x24;                             // Id
+    payLoad_.buffer[2] = sizeof(NavigationEngineSettings); // Length LSB
+    payLoad_.buffer[3] = 0;                                // Length MSB
+    memcpy(&payLoad_.buffer[4],(uint8_t*)navDynModel,sizeof(NavigationEngineSettings));
+
+    (void) this->send(payLoad_.buffer,sizeof(NavigationEngineSettings)+4);
+    return this->wait();
+}
+
 /* 
  *  Sets the message rate.
  *  See "CFG-MSG" in u-blox protocol description.

--- a/SodaqOneTracker_v3/ublox.h
+++ b/SodaqOneTracker_v3/ublox.h
@@ -90,6 +90,47 @@ typedef struct __attribute__((packed,aligned(1))) TimePulseTimedata {
     uint8_t     reserved1;
 } TimePulseTimedata;
 
+typedef struct __attribute__((packed,aligned(1))) NavigationEngineSettings {
+    uint16_t mask;              // Parameters Bitmask. Only the masked parameters will be applied.
+    uint8_t  dynModel;          // Dynamic platform model:
+                                // 0: portable
+                                // 2: stationary
+                                // 3: pedestrian
+                                // 4: automotive
+                                // 5: sea
+                                // 6: airborne with <1g acceleration
+                                // 7: airborne with <2g acceleration
+                                // 8: airborne with <4g acceleration
+                                // 9: wrist worn watch (not supported in protocol versions less than 18)
+    uint8_t  fixMode;           // Position Fixing Mode: 1: 2D only 2: 3D only 3: auto 2D/3D
+    int32_t  fixedAlt;          // Fixed altitude in meters (mean sea level) for 2D fix mode
+    uint32_t fixedAltVar;       // Fixed altitude variance for 2D mode in m^2.
+    int8_t   minElev;           // Minimum Elevation in degrees for a GNSS satellite to be used in NAV
+    uint8_t  drLimit;           // Reserved
+    uint16_t pDop;              // Position DOP Mask to use
+    uint16_t tDop;              // Time DOP Mask to use
+    uint16_t pAcc;              // Position Accuracy Mask in meters
+    uint16_t tAcc;              // Time Accuracy Mask in meters
+    uint8_t  staticHoldThresh;  // Static hold threshold in cm/s
+    uint8_t  dgnssTimeout;      // DGNSS timeout in seconds
+    uint8_t  cnoThreshNumSats;  // Number of sattelites required to have C/NO above cnoThresh 
+                                // for a fix to be attempted
+    uint8_t  cnoThresh;         // C/N0 threshold for deciding whether to attempt a fix in dBHz
+    uint8_t  reserved1[2];      // 2 bytes reserved
+    uint16_t staticHoldMaxDist; // Static hold distance threshold before quitting static hold
+    uint8_t  utcStandard;       // UTC standard to be used:
+                                // 0: Automatic; receiver selects based on GNSS configuration 
+                                //    (see GNSS time bases).
+                                // 3: UTC as operated by the U.S. Naval Observatory (USNO); 
+                                //    derived from GPS time
+                                // 6: UTC as operated by the former Soviet Union; derived from 
+                                //    GLONASS time
+                                // 7: UTC as operated by the National Time Service Center,
+                                //    China; derived from BeiDou time
+                                //    (not supported in protocol versions less than 16).
+    uint8_t  reserved2[5];      // 5 bytes reserved
+} NavigationEngineSettings;
+
 enum Messages {
     UBX_NAV_PVT = 0x0107,
     UBX_TIM_TP  = 0x0d01,
@@ -127,6 +168,8 @@ public:
     //
     bool    getTimePulseParameters(uint8_t tpIdx,TimePulseParameters* tpp);
     bool    getPortConfigurationDDC(PortConfigurationDDC* pcd);
+    
+    bool    getNavEngineSettings(NavigationEngineSettings* navDynModel);
 
     void    GetPeriodic();
     void    GetPeriodic(int bytes);

--- a/SodaqOneTracker_v3/ublox.h
+++ b/SodaqOneTracker_v3/ublox.h
@@ -102,7 +102,10 @@ typedef struct __attribute__((packed,aligned(1))) NavigationEngineSettings {
                                 // 7: airborne with <2g acceleration
                                 // 8: airborne with <4g acceleration
                                 // 9: wrist worn watch (not supported in protocol versions less than 18)
-    uint8_t  fixMode;           // Position Fixing Mode: 1: 2D only 2: 3D only 3: auto 2D/3D
+    uint8_t  fixMode;           // Position Fixing Mode:
+                                // 1: 2D only 
+                                // 2: 3D only 
+                                // 3: auto 2D/3D
     int32_t  fixedAlt;          // Fixed altitude in meters (mean sea level) for 2D fix mode
     uint32_t fixedAltVar;       // Fixed altitude variance for 2D mode in m^2.
     int8_t   minElev;           // Minimum Elevation in degrees for a GNSS satellite to be used in NAV
@@ -157,19 +160,20 @@ class UBlox {
 public:
     // NavigationPositionVelocityTimeSolution *NavPvt;
     // TimePulseParameters *CfgTp;
-    //
+
     UBlox   ();
     UBlox   (TwoWire& Wire,uint8_t address);
     void    CfgMsg(uint16_t Msg,uint8_t rate);
     int     available();
-    //
-    int     setPortConfigurationDDC(PortConfigurationDDC *pcd);
-    int     setTimePulseParameters(TimePulseParameters *Tpp);
-    //
-    bool    getTimePulseParameters(uint8_t tpIdx,TimePulseParameters* tpp);
+
     bool    getPortConfigurationDDC(PortConfigurationDDC* pcd);
+    int     setPortConfigurationDDC(PortConfigurationDDC *pcd);
+
+    bool    getTimePulseParameters(uint8_t tpIdx,TimePulseParameters* tpp);
+    int     setTimePulseParameters(TimePulseParameters *Tpp);
     
     bool    getNavEngineSettings(NavigationEngineSettings* navDynModel);
+    bool    setNavEngineSettings(NavigationEngineSettings* navDynModel);
 
     void    GetPeriodic();
     void    GetPeriodic(int bytes);
@@ -185,9 +189,9 @@ public:
     // Debug helper
     void    db_printf(const char *message,...);
 
-    //
     int     process(uint8_t);
     void    sendraw();
+
 private:
     int     send(uint8_t *buffer,int n);
     int     wait();


### PR DESCRIPTION
Adds support for selecting different GPS Dynamic Models, in order to support high altitude ballooning or rocket use.

Selecting a different model is done through a new configuration setting `GPS dynamic model (gdm=): 0`, with all available options described in the README.md. 